### PR TITLE
Fix interceptors

### DIFF
--- a/django_grpc_framework/management/commands/grpcrunserver.py
+++ b/django_grpc_framework/management/commands/grpcrunserver.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
 
     def _serve(self):
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=self.max_workers),
-                             interceptors=grpc_settings.SERVER_INTERCEPTORS)
+                             interceptors=[interceptor() for interceptor in grpc_settings.SERVER_INTERCEPTORS])
         grpc_settings.ROOT_HANDLERS_HOOK(server)
         server.add_insecure_port(self.address)
         server.start()

--- a/django_grpc_framework/settings.py
+++ b/django_grpc_framework/settings.py
@@ -20,7 +20,7 @@ DEFAULTS = {
     'ROOT_HANDLERS_HOOK': None,
 
     # gRPC server configuration
-    'SERVER_INTERCEPTORS': None,
+    'SERVER_INTERCEPTORS': [],
 }
 
 


### PR DESCRIPTION
The `grpc.server` expects the `interceptors` parameter to be a list of `ServerInterceptor` objects not classes. This fix would instantiate them before passing them to the `grpc.server`